### PR TITLE
Add check to lint open api spec

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,6 @@ jobs:
        - uses: actions/checkout@v4
          
        # Run Spectral and lint the OpenAPI file(s)
-       - uses: stoplightio/spectral-action@v1
+       - uses: stoplightio/spectral-action@latest
          with:
            file_glob: "openapi/trireg2.yaml"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,18 @@
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - 'openapi/**'
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+       # checkout repository
+       - uses: actions/checkout@v4
+         
+       # Run Spectral and lint the OpenAPI file(s)
+       - uses: stoplightio/spectral-action@v1
+         with:
+           file_glob: "openapi/trireg2.yaml"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'openapi/**'
+      - '.spectral.yaml'
 
 jobs:
   archive:

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,8 @@
+# A Spectral configuration file is a YAML file that defines the rules that Spectral will use to lint your API description document.
+# All rules are enabled by default, but you can disable them by setting their severity to off.
+# https://docs.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets 
+
+extends: [
+  # Spectral Default Rules:
+  [ "spectral:oas", all ]
+]


### PR DESCRIPTION
Added usage of Spectral to validate the openapi specification

* Added `.spectral.yaml` file with validation rules (default: all)
* Added github workflow check to lint the results on all PR's with changes to the specification files  