### PR TITLE
Long identifiers

### DIFF
--- a/openapi/schemas/ImportRegistrationRequest.yaml
+++ b/openapi/schemas/ImportRegistrationRequest.yaml
@@ -3,9 +3,11 @@ items:
   required: ["userId", "taskId", "date", "duration", "tags"]
   properties:
     userId:
-      type: "string"
+      type: "integer"
+      format: "int64"
     taskId:
-      type: "string"
+      type: "integer"
+      format: "int64"
     date:
       type: "string"
       format: "date"

--- a/openapi/schemas/ImportRegistrationResponse.yaml
+++ b/openapi/schemas/ImportRegistrationResponse.yaml
@@ -3,7 +3,8 @@ items:
   required: ["timeRegistrationId", "status"]
   properties:
     timeRegistrationId:
-      type: "string"
+      type: "integer"
+      format: "int64"
     status:
       type: "string"
       description: "Describes the status of the registration (SUCCESS, PENDING, FAILED)"

--- a/openapi/schemas/Tag.yaml
+++ b/openapi/schemas/Tag.yaml
@@ -2,6 +2,7 @@ type: object
 required: ["tagConfigurationId"]
 properties:
   tagConfigurationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   value:
     type: "string"

--- a/openapi/schemas/TagConfigurationResponse.yaml
+++ b/openapi/schemas/TagConfigurationResponse.yaml
@@ -3,7 +3,8 @@ items:
   required: ["tagConfigurationId", "tagConfigurationName", "tagDescription", "tagValueType", "tagTaskRelation"]
   properties:
     tagConfigurationId:
-      type: "string"
+      type: "integer"
+      format: "int64"
     tagConfigurationName:
       type: "string"
       description: "The name of the tag configuration"

--- a/openapi/schemas/TagTimeRegistrationRequest.yaml
+++ b/openapi/schemas/TagTimeRegistrationRequest.yaml
@@ -2,8 +2,10 @@ type: "object"
 required: ["timeRegistrationId", "tagConfigurationId"]
 properties:
   timeRegistrationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   tagConfigurationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   value:
     type: "string"

--- a/openapi/schemas/TagTimeRegistrationResponse.yaml
+++ b/openapi/schemas/TagTimeRegistrationResponse.yaml
@@ -2,6 +2,7 @@ type: "object"
 required: ["tagConfigurationId"]
 properties:
   tagConfigurationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   tagValue:
     type: "string"

--- a/openapi/schemas/TaskCreateResponse.yaml
+++ b/openapi/schemas/TaskCreateResponse.yaml
@@ -3,7 +3,8 @@ items:
   required: ["taskId", "name"]
   properties:
     taskId:
-      type: "string"
+      type: "integer"
+      format: "int64"
     name:
       type: "string"
       description: "The name of the task"

--- a/openapi/schemas/TimeRegistrationRequest.yaml
+++ b/openapi/schemas/TimeRegistrationRequest.yaml
@@ -2,7 +2,8 @@ type: "object"
 required: ["taskId", "date", "duration"]
 properties:
   taskId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   date:
     type: "string"
     format: "date"

--- a/openapi/schemas/TimeRegistrationResponse.yaml
+++ b/openapi/schemas/TimeRegistrationResponse.yaml
@@ -2,15 +2,18 @@ type: "object"
 required: ["timeRegistrationId", "registered", "userId", "taskId", "date", "duration", "status"]
 properties:
   timeRegistrationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   registered:
     type: "integer"
     format: "int64"
     description: "The registration time as Unix milliseconds timestamp"
   userId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   taskId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   date:
     type: "string"
     format: "date"

--- a/openapi/schemas/TimeRegistrationsByTaskResponse.yaml
+++ b/openapi/schemas/TimeRegistrationsByTaskResponse.yaml
@@ -3,7 +3,8 @@ items:
   type: object
   properties:
     taskId:
-      type: string
+      type: "integer"
+      format: "int64"
     taskName:
       type: string
     taskDescription:
@@ -15,7 +16,8 @@ items:
         required: [ "timeRegistrationId", "registered", "date", "duration", "status" ]
         properties:
           timeRegistrationId:
-            type: "string"
+            type: "integer"
+            format: "int64"
           registered:
             type: "integer"
             format: "int64"

--- a/openapi/schemas/admin/TagTaskMappingCreateRequest.yaml
+++ b/openapi/schemas/admin/TagTaskMappingCreateRequest.yaml
@@ -2,9 +2,11 @@ type: "object"
 required: ["tagConfigurationId", "taskId", "relation"]
 properties:
   tagConfigurationId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   taskId:
-    type: "string"
+    type: "integer"
+    format: "int64"
   relation:
     type: "string"
     description: "The type of relation between the task and tag."

--- a/openapi/tagConfiguration.yaml
+++ b/openapi/tagConfiguration.yaml
@@ -9,7 +9,8 @@ get:
       description: "The id of the task to get applicable tag configurations for"
       required: true
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
     - name: "includeHidden"
       in: "query"
       description: "Include tags that are normally hidden and automatically added when registering time on the task"
@@ -64,7 +65,8 @@ put:
       description: "The id of the tag configuration to update"
       required: true
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
   requestBody:
     required: true
     content:

--- a/openapi/tagging.yaml
+++ b/openapi/tagging.yaml
@@ -7,7 +7,8 @@ get:
     - in: query
       name: "timeRegistrationId"
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
       required: true
       description: "The ID of the registration to get tags for"
   responses:
@@ -67,7 +68,8 @@ put:
           required: ["tagId", "value"]
           properties:
             tagId:
-              type: "string"
+              type: "integer"
+              format: "int64"
             value:
               type: "string"
   responses:
@@ -92,7 +94,8 @@ delete:
     - in: query
       name: "tagId"
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
       required: true
       description: "The ID of the tag to delete"
   responses:

--- a/openapi/tasks.yaml
+++ b/openapi/tasks.yaml
@@ -9,7 +9,8 @@ get:
       description: "The id of the user to get tasks for (Default is user logged in)"
       required: false
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
   responses:
     "200":
       description: "Successfully fetched list of tasks"
@@ -59,7 +60,8 @@ put:
       description: "The id of the task to update"
       required: true
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
   requestBody:
     required: true
     content:

--- a/openapi/time-registration.yaml
+++ b/openapi/time-registration.yaml
@@ -49,7 +49,8 @@ put:
       description: "The id of the time registration to update"
       required: true
       schema:
-        type: "string"
+        type: "integer"
+        format: "int64"
   requestBody:
     required: true
     content:


### PR DESCRIPTION
Change all String identifiers for entities to Longs in preparation for database integration, since the database will generate from id-sequences.