### PR TITLE
Tag configuration api improvements

### DIFF
--- a/openapi/admin/tagConfiguration.yaml
+++ b/openapi/admin/tagConfiguration.yaml
@@ -2,32 +2,28 @@ get:
   tags:
     - "TagConfiguration"
   operationId: "getTagConfigurations"
-  description: "Gets all tag configurations that are applicable to the provided task"
+  description: "Gets tag configurations based on the provided query parameters"
   parameters:
-    - name: "taskId"
+    - name: "tagConfigurationId"
       in: "query"
-      description: "The id of the task to get applicable tag configurations for"
-      required: true
+      description: "The id of the tag configuration to get. If unspecified, all tag configurations are returned"
+      required: false
       schema:
         type: "integer"
         format: "int64"
-    - name: "includeHidden"
-      in: "query"
-      description: "Include tags that are normally hidden and automatically added when registering time on the task"
-      required: false
-      schema:
-        type: "boolean"
   responses:
     "200":
-      description: "List of valid tag configurations for the specified task"
+      description: "List of tag configurations for the provided query parameters"
       content:
         application/json:
           schema:
-            $ref: "../schemas/admin/TagConfigurationResponse.yaml"
+            type: "array"
+            items:
+              $ref: "../schemas/admin/TagConfigurationResponse.yaml"
     "401":
       $ref: "../responses/UnauthorizedError.yaml"
     "404":
-      description: "Unable to find tag configurations for the specified task (No task with specified taskId exists)"
+      description: "Unable to find tag configurations for the query parameters (e.g. no tag configuration with specified id exists)"
 post:
   tags:
     - "TagConfiguration"
@@ -89,7 +85,7 @@ put:
     "401":
       $ref: "../responses/UnauthorizedError.yaml"
     "404":
-      description: "The specified task configuration was not found"
+      description: "The specified tag configuration was not found"
       content:
         text/plain:
           schema:

--- a/openapi/admin/tagTaskMapping.yaml
+++ b/openapi/admin/tagTaskMapping.yaml
@@ -1,3 +1,35 @@
+get:
+  tags:
+    - "TagTaskMapping"
+  operationId: "getTagTaskMappings"
+  description: "Gets all tag configurations that are associated to the provided task"
+  parameters:
+    - name: "taskId"
+      in: "query"
+      description: "The id of the task to get associated tag configurations for"
+      required: true
+      schema:
+        type: "integer"
+        format: "int64"
+    - name: "includeHidden"
+      in: "query"
+      description: "Include tags that are normally hidden and automatically added when registering time on the task"
+      required: false
+      schema:
+        type: "boolean"
+  responses:
+    "200":
+      description: "List of valid tag configurations for the specified task"
+      content:
+        application/json:
+          schema:
+            type: "array"
+            items:
+              $ref: "../schemas/admin/TagTaskConfigurationResponse.yaml"
+    "401":
+      $ref: "../responses/UnauthorizedError.yaml"
+    "404":
+      description: "Unable to find tag configurations for the specified task (No task with specified taskId exists)"
 post:
   tags:
     - "TagTaskMapping"
@@ -24,3 +56,43 @@ post:
             type: "string"
     "401":
       $ref: "../responses/UnauthorizedError.yaml"
+put:
+  tags:
+    - "TagTaskMapping"
+  operationId: "updateTagTaskMapping"
+  description: "Updates a relation between a task and a tag configuration"
+  parameters:
+    - name: "tagTaskMappingId"
+      in: "query"
+      description: "The id of the relation to update"
+      required: true
+      schema:
+        type: "integer"
+        format: "int64"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/admin/TagTaskMappingUpdateRequest.yaml"
+  responses:
+    "200":
+      description: "The relation was successfully updated"
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/DefaultUpdateResponse.yaml"
+    "400":
+      description: "Request contains invalid data. The relation was not updated"
+      content:
+        text/plain:
+          schema:
+            type: "string"
+    "401":
+      $ref: "../responses/UnauthorizedError.yaml"
+    "404":
+      description: "The specified relation was not found"
+      content:
+        text/plain:
+          schema:
+            type: "string"

--- a/openapi/schemas/admin/TagConfigurationCreateRequest.yaml
+++ b/openapi/schemas/admin/TagConfigurationCreateRequest.yaml
@@ -8,5 +8,4 @@ properties:
     type: "string"
     description: "A description of the tag configuration"
   tagConfigurationValueType:
-    type: "string"
-    description: "Describes the value type of the tag"
+    $ref: "TagConfigurationValueType.yaml"

--- a/openapi/schemas/admin/TagConfigurationResponse.yaml
+++ b/openapi/schemas/admin/TagConfigurationResponse.yaml
@@ -1,22 +1,14 @@
-type: "array"
-items:
-  required: ["tagConfigurationId", "tagConfigurationName", "tagDescription", "tagValueType", "tagTaskRelation"]
-  properties:
-    tagConfigurationId:
-      type: "integer"
-      format: "int64"
-    tagConfigurationName:
-      type: "string"
-      description: "The name of the tag configuration"
-    tagDescription:
-      type: "string"
-      description: "A description of the tag configuration"
-    tagValueType:
-      type: "string"
-      description: "Describes the value type of the tag"
-    tagDefaultValue:
-      type: "string"
-      description: "The default value to use when no other value is specified when adding a tag to a time registration"
-    tagTaskRelation:
-      type: "string"
-      description: "Specifies the relation to the task. For example, whether the tag is optional or mandatory"
+type: "object"
+required: ["tagConfigurationId", "tagConfigurationName", "tagConfigurationValueType"]
+properties:
+  tagConfigurationId:
+    type: "integer"
+    format: "int64"
+  tagConfigurationName:
+    type: "string"
+    description: "The name of the tag configuration"
+  tagConfigurationDescription:
+    type: "string"
+    description: "A description of the tag configuration"
+  tagConfigurationValueType:
+    $ref: "TagConfigurationValueType.yaml"

--- a/openapi/schemas/admin/TagConfigurationUpdateRequest.yaml
+++ b/openapi/schemas/admin/TagConfigurationUpdateRequest.yaml
@@ -7,5 +7,4 @@ properties:
     type: "string"
     description: "A description of the tag configuration"
   tagConfigurationValueType:
-    type: "string"
-    description: "Describes the value type of the tag"
+    $ref: "TagConfigurationValueType.yaml"

--- a/openapi/schemas/admin/TagConfigurationValueType.yaml
+++ b/openapi/schemas/admin/TagConfigurationValueType.yaml
@@ -1,0 +1,6 @@
+type: "string"
+description: "Describes the value type of the tag"
+enum:
+  - "string"
+  - "bool"
+  - "int"

--- a/openapi/schemas/admin/TagTaskConfigurationResponse.yaml
+++ b/openapi/schemas/admin/TagTaskConfigurationResponse.yaml
@@ -1,0 +1,31 @@
+type: "object"
+required: ["tagTaskMappingId", "tagConfigurationId", "taskId", "tagConfigurationName", "tagValueType", "tagTaskRelation"]
+description: "A mapping between a tag configuration and a task, specifying the relation between the two. A tag configuration can be mapped to different tasks with different relation-types. For example, a tag configuration can be mandatory for one task, and optional for another."
+properties:
+  tagTaskMappingId:
+    type: "integer"
+    format: "int64"
+    description: "An identifier for this mapping"
+  tagConfigurationId:
+    type: "integer"
+    format: "int64"
+    description: "The id for the tag configuration that this mapping is associated to"
+  taskId:
+    type: "integer"
+    format: "int64"
+    description: "The id for the task that this mapping is associated to"
+  tagConfigurationName:
+    type: "string"
+    description: "The name of the tag configuration"
+  tagDescription:
+    type: "string"
+    description: "A description of the tag configuration"
+  tagValueType:
+    type: "string"
+    description: "Describes the value type of the tag"
+  tagDefaultValue:
+    type: "string"
+    description: "The default value to use when no other value is specified when adding a tag to a time registration"
+  tagTaskRelation:
+    type: "string"
+    description: "Specifies the relation to the task. For example, whether the tag is optional or mandatory"

--- a/openapi/schemas/admin/TagTaskMappingCreateRequest.yaml
+++ b/openapi/schemas/admin/TagTaskMappingCreateRequest.yaml
@@ -8,13 +8,8 @@ properties:
     type: "integer"
     format: "int64"
   relation:
-    type: "string"
-    description: "The type of relation between the task and tag"
-    enum:
-      - "optional"
-      - "mandatory"
-      - "hidden"
+    $ref: "TagTaskRelationType.yaml"
   defaultValue:
     type: "string"
     default: ""
-    description: "The default value to use when adding the tag to a tag configuration"
+    description: "The default value to use when adding the tag to the task"

--- a/openapi/schemas/admin/TagTaskMappingUpdateRequest.yaml
+++ b/openapi/schemas/admin/TagTaskMappingUpdateRequest.yaml
@@ -1,0 +1,9 @@
+type: "object"
+required: ["relation"]
+properties:
+  relation:
+    $ref: "TagTaskRelationType.yaml"
+  defaultValue:
+    type: "string"
+    default: ""
+    description: "The default value to use when adding the tag to a the task"

--- a/openapi/schemas/admin/TagTaskRelationType.yaml
+++ b/openapi/schemas/admin/TagTaskRelationType.yaml
@@ -1,0 +1,6 @@
+type: "string"
+description: "The type of relation between the task and tag"
+enum:
+  - "optional"
+  - "mandatory"
+  - "hidden"

--- a/openapi/schemas/admin/TagTimeRegistrationRequest.yaml
+++ b/openapi/schemas/admin/TagTimeRegistrationRequest.yaml
@@ -1,5 +1,5 @@
 type: "object"
-required: ["timeRegistrationId", "tagConfigurationId"]
+required: ["timeRegistrationId", "tagConfigurationId", "value"]
 properties:
   timeRegistrationId:
     type: "integer"


### PR DESCRIPTION
closes #46, closes #49

- Separate tag-configuration and tag-task-mapping apis. The former handles CRUD of tag configuration entities and the latter handles CRUD of tag/task mappings.
- Change enumerated 'relation' text to actual enumeration
- Cleaned up mandatory/optional elements. In general, tag values are mandatory, default values and descriptions are not.