### PR TITLE
Change openapi enums to upper case

### DIFF
--- a/openapi/schemas/admin/ExportSettingValueType.yaml
+++ b/openapi/schemas/admin/ExportSettingValueType.yaml
@@ -2,10 +2,10 @@ type: "string"
 description: >
   An enumeration of the different types of export settings.
   Valid values:
-  * `int64` - A 64 bit integer.
-  * `string` - A string.
-  * `uri` - A Uniform Resource Locator.
+  * `INT64` - A 64 bit integer.
+  * `STRING` - A string.
+  * `URI` - A Uniform Resource Locator.
 enum:
-  - "int64"
-  - "string"
-  - "url"
+  - "INT64"
+  - "STRING"
+  - "URL"

--- a/openapi/schemas/admin/TagConfigurationValueType.yaml
+++ b/openapi/schemas/admin/TagConfigurationValueType.yaml
@@ -1,6 +1,6 @@
 type: "string"
 description: "Describes the value type of the tag"
 enum:
-  - "string"
-  - "bool"
-  - "int"
+  - "STRING"
+  - "BOOL"
+  - "INT"

--- a/openapi/schemas/admin/TagTaskRelationType.yaml
+++ b/openapi/schemas/admin/TagTaskRelationType.yaml
@@ -1,6 +1,6 @@
 type: "string"
 description: "The type of relation between the task and tag"
 enum:
-  - "optional"
-  - "mandatory"
-  - "hidden"
+  - "OPTIONAL"
+  - "MANDATORY"
+  - "HIDDEN"

--- a/openapi/schemas/admin/UserGroupRelationType.yaml
+++ b/openapi/schemas/admin/UserGroupRelationType.yaml
@@ -1,15 +1,15 @@
 type: "string"
 enum:
-  - "Member"
-  - "MemberReader"
-  - "MemberWriter"
-  - "MemberProtectedReader"
-  - "MemberProtectedWriter"
+  - "MEMBER"
+  - "MEMBER_READER"
+  - "MEMBER_WRITER"
+  - "MEMBER_PROTECTED_READER"
+  - "MEMBER_PROTECTED_WRITER"
 description: >
   Describes a user's relation to a user group
   Valid values:
-  * `Member` - Ordinary relation to the user group with no special rights
-  * `MemberReader` - User is a member of the group and is allowed to read data of other members
-  * `MemberWriter` - User is a member of the group and is allowed to read and write data of other members
-  * `MemberProtectedReader` - User is a member of the group and is allowed to read data of other members while own data cannot be read/written by others in the group
-  * `MemberProtectedWriter` - User is a member of the group and is allowed to read and write data of other members while own data cannot be read/written by others in the group
+  * `MEMBER` - Ordinary relation to the user group with no special rights
+  * `MEMBER_READER` - User is a member of the group and is allowed to read data of other members
+  * `MEMBER_WRITER` - User is a member of the group and is allowed to read and write data of other members
+  * `MEMBER_PROTECTED_READER` - User is a member of the group and is allowed to read data of other members while own data cannot be read/written by others in the group
+  * `MEMBER_PROTECTED_WRITER` - User is a member of the group and is allowed to read and write data of other members while own data cannot be read/written by others in the group

--- a/openapi/schemas/admin/UserPermissionType.yaml
+++ b/openapi/schemas/admin/UserPermissionType.yaml
@@ -1,19 +1,19 @@
 type: "string"
 enum:
-  - "ModifyConfigurations"
-  - "ModifyTasks"
-  - "ModifyGroups"
-  - "ModifyPermissions"
-  - "ModifyExportSettings"
-  - "ReadAll"
-  - "WriteAll"
+  - "MODIFY_CONFIGURATIONS"
+  - "MODIFY_TASKS"
+  - "MODIFY_GROUPS"
+  - "MODIFY_PERMISSIONS"
+  - "MODIFY_EXPORT_SETTINGS"
+  - "READ_ALL"
+  - "WRITE_ALL"
 description: >
   Describes a user's permission to performing certain operations
   Valid values:
-  * `ModifyConfigurations` - User is allowed to create, edit, update, and delete tag configurations and define the relation to existing tasks
-  * `ModifyTasks` - User is allowed to create, edit, update, and delete tasks
-  * `ModifyGroups` - User is a allowed to modify create, modify, and update user groups
-  * `ModifyPermissions` - User is allowed to add and remove permissions from a user
-  * `ModifyExportSettings` - User is allowed to to create, edit, update, and delete settings for exporting data
-  * `ReadAll` - User can read data registered by all users
-  * `WriteAll` - User can read and write data registered by all users
+  * `MODIFY_CONFIGURATIONS` - User is allowed to create, edit, update, and delete tag configurations and define the relation to existing tasks
+  * `MODIFY_TASKS` - User is allowed to create, edit, update, and delete tasks
+  * `MODIFY_GROUPS` - User is a allowed to modify create, modify, and update user groups
+  * `MODIFY_PERMISSIONS` - User is allowed to add and remove permissions from a user
+  * `MODIFY_EXPORT_SETTINGS` - User is allowed to to create, edit, update, and delete settings for exporting data
+  * `READ_ALL` - User can read data registered by all users
+  * `WRITE_ALL` - User can read and write data registered by all users

--- a/openapi/schemas/user/ImportTimeRegistrationStatus.yaml
+++ b/openapi/schemas/user/ImportTimeRegistrationStatus.yaml
@@ -1,11 +1,11 @@
 type: "string"
 enum:
-  - "valid"
-  - "pending"
-  - "failed"
+  - "VALID"
+  - "PENDING"
+  - "FAILED"
 description: >
   The status of importing a time registration
   Valid values:
-  * `valid` - The time registration is valid and has been imported successfully
-  * `pending` - The time registration is valid, but is awaiting the approval of the user. Used when a user imports data for another user.
-  * `failed` - Something is wrong with the time registration, it has not been imported.
+  * `VALID` - The time registration is valid and has been imported successfully
+  * `PENDING` - The time registration is valid, but is awaiting the approval of the user. Used when a user imports data for another user.
+  * `FAILED` - Something is wrong with the time registration, it has not been imported.

--- a/openapi/schemas/user/KmRegistrationStatus.yaml
+++ b/openapi/schemas/user/KmRegistrationStatus.yaml
@@ -1,7 +1,7 @@
 type: "string"
 description: "Describes the status of the kilometre registration"
 enum:
-  - "pending"
-  - "accepted"
-  - "rejected"
-  - "deleted"
+  - "PENDING"
+  - "ACCEPTED"
+  - "REJECTED"
+  - "DELETED"

--- a/openapi/schemas/user/KmRegistrationUpdateRequest.yaml
+++ b/openapi/schemas/user/KmRegistrationUpdateRequest.yaml
@@ -12,7 +12,7 @@ properties:
   status:
     type: "string"
     enum:
-      - "approve"
-      - "reject"
-      - "pending"
-    default: "pending"
+      - "APPROVE"
+      - "REJECT"
+      - "PENDING"
+    default: "PENDING"

--- a/openapi/schemas/user/TagConfigurationMetadata.yaml
+++ b/openapi/schemas/user/TagConfigurationMetadata.yaml
@@ -17,24 +17,24 @@ properties:
   cardinality:
     type: "string"
     enum:
-      - "optional"
-      - "mandatory"
-      - "managed"
+      - "OPTIONAL"
+      - "MANDATORY"
+      - "MANAGED"
     description: >
       The status of a time registration
       Valid values:
-      * `optional` - The tag can be added to this time registration, but it is not required.
-      * `mandatory` - The tag must be added to this time registration.
-      * `managed` - The tag is managed by administrator configuration. It is read-only and can't be changed.
+      * `OPTIONAL` - The tag can be added to this time registration, but it is not required.
+      * `MANDATORY` - The tag must be added to this time registration.
+      * `MANAGED` - The tag is managed by administrator configuration. It is read-only and can't be changed.
   valueType:
     type: "string"
     enum:
-      - "string"
-      - "bool"
-      - "int"
+      - "STRING"
+      - "BOOL"
+      - "INT"
     description: >
       The value type of this configuration
       Valid values:
-      * `string` - The tag value can be any string
-      * `bool` - The tag value must be a boolean on the form 'true' or 'false' (case insensitive)
-      * `int` - The tag value must be a valid 32-bit integer
+      * `STRING` - The tag value can be any string
+      * `BOOL` - The tag value must be a boolean on the form 'true' or 'false' (case insensitive)
+      * `INT` - The tag value must be a valid 32-bit integer

--- a/openapi/schemas/user/TimeRegistrationStatus.yaml
+++ b/openapi/schemas/user/TimeRegistrationStatus.yaml
@@ -1,15 +1,15 @@
 type: "string"
 enum:
-  - "valid"
-  - "pending"
-  - "invalid"
-  - "deleted"
-  - "rejected"
+  - "VALID"
+  - "PENDING"
+  - "INVALID"
+  - "DELETED"
+  - "REJECTED"
 description: >
   The status of a time registration
   Valid values:
-  * `valid` - The time registration is valid
-  * `pending` - The time registration is valid as such, but is awaiting the approval of the user. If this happens, it will become 'valid'. If it is rejected, it will become 'rejected'.
-  * `invalid` - Something is wrong with the time registration, it will need correction before it can become valid
-  * `deleted` - The time registration has existed at some point, but has now been deleted
-  * `rejected` - The time registration has been rejected by the user
+  * `VALID` - The time registration is valid
+  * `PENDING` - The time registration is valid as such, but is awaiting the approval of the user. If this happens, it will become 'valid'. If it is rejected, it will become 'rejected'.
+  * `INVALID` - Something is wrong with the time registration, it will need correction before it can become valid
+  * `DELETED` - The time registration has existed at some point, but has now been deleted
+  * `REJECTED` - The time registration has been rejected by the user


### PR DESCRIPTION
- Some initial work on a Java spring client has issues with our openapi enumerations, which are not upper case. We don't really care, so they can just be changed.